### PR TITLE
Skip report tests for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         run: npm run test:all
       - name: Upload report (dry run)
         uses: ./
+        if: ${{github.triggering_actor != 'dependabot[bot]'}}
         with:
           aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -113,6 +114,7 @@ jobs:
           dry-run: true
       - name: Upload report
         uses: ./
+        if: ${{github.triggering_actor != 'dependabot[bot]'}}
         with:
           aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}


### PR DESCRIPTION
Not the best solution but until those secrets are available for dependabot run this will at least let them pass.