### PR TITLE
Better dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,24 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      aws-clients:
+        dependency-type: production
+        patterns: '@aws-sdk/*'
     ignore:
       # update-dependencies workflow already handles minor/patch updates
+      - dependency-name: '@actions/*'
+        dependency-type: production
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
+      - dependency-name: '@aws-sdk/*'
+        dependency-type: production
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
       - dependency-name: '*'
+        dependency-type: development
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch


### PR DESCRIPTION
This should allow auto updating of the `d2l-test-reporting` dependency. Once it becomes `1.0.0` this won't be an issue anymore.