### PR TITLE
Update to new post mode for build comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
             New build required - pull request
             #${{steps.changes.outputs.pull-request-number}} has been opened with
             new built files.
+          post-mode: hide-previous
       - name: Report status
         if: >
           steps.changes.outputs.pull-request-operation == 'created' ||


### PR DESCRIPTION
This way if a new build is opened the old one is minimized, easier to read/ignore out of date stuff that way.