### PR TITLE
Remove default code owners from `package.json`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @Brightspace/quality-enablement-reviewers
 dist/
 package-lock.json
+package.json


### PR DESCRIPTION
Need this to allow auto merge stuff to work.