### PR TITLE
Widen range for `d2l-test-reporting`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 * @Brightspace/quality-enablement-reviewers
 dist/
 package-lock.json
-package.json

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@actions/core": "^1",
     "@aws-sdk/client-sts": "^3",
     "@aws-sdk/client-timestream-write": "^3",
-    "d2l-test-reporting": "^3.1.2"
+    "d2l-test-reporting": "^3"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38",


### PR DESCRIPTION
This should result in auto updates not including us unless a major bump happens which I'd like to be on. All other stuff should just fly under the radar.