### PR TITLE
Add default reviewer group on failed bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,23 @@ jobs:
           aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           aws-session-token: ${{secrets.AWS_SESSION_TOKEN}}
+  handle:
+    name: Handle Automations
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - licenses
+      - build
+      - test
+    permissions:
+      contents: read
+      pull-requests: write
+    if: failure() && contains(github.triggering_actor, '[bot]')
+    steps:
+      - name: Add reviewers
+        run: gh pr edit --add-reviewer "$REVIEWERS" "$PULL_REQUEST_URL"
+        env:
+          PULL_REQUEST_URL: ${{github.event.pull_request.html_url}}
+          REVIEWERS: Brightspace/quality-enablement-reviewers
+          GITHUB_TOKEN: ${{github.token}}


### PR DESCRIPTION
Will help us catch failures for automated PR's.