### PR TITLE
Remove add reviewers workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,29 +115,3 @@ jobs:
           aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           aws-session-token: ${{secrets.AWS_SESSION_TOKEN}}
-  reviewers:
-    name: Add Reviewers
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    needs:
-      - lint
-      - licenses
-      - build
-      - test
-    permissions:
-      contents: read
-      pull-requests: write
-    if: failure() && contains(github.triggering_actor, '[bot]')
-    steps:
-      - name: Add reviewers
-        run: >
-          gh api
-          -X 'POST'
-          -H 'Accept: application/vnd.github+json'
-          -H 'X-GitHub-Api-Version: 2022-11-28'
-          "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST_NUMBER/requested_reviewers"
-          -f "team_reviewers[]=$REVIEWERS"
-        env:
-          PULL_REQUEST_NUMBER: ${{github.event.pull_request.number}}
-          REVIEWERS: quality-enablement-reviewers # must not include organization name
-          GITHUB_TOKEN: ${{github.token}}


### PR DESCRIPTION
Not gonna work cause GitHub's permission is kinda stupid. Makes me sad. If I figure out a workaround I'll add it back.