### PR TITLE
Add ignore rule for `eslint` for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+      - dependency-name: eslint
+        versions: >= 9
     groups:
       aws-clients:
         dependency-type: production

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
       - dependency-name: eslint
-        versions: >= 9
+        versions: '>= 9'
     groups:
       aws-clients:
         dependency-type: production


### PR DESCRIPTION
There are issues with `eslint` updates for version `9` and greater. Ignore them for now to stop spam Prs