### PR TITLE
QE-739: Fix `.editorconfig` linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "license-check": "d2l-license-checker -p",
     "lint": "npm run lint:eslint && npm run lint:editorconfig",
     "lint:eslint": "eslint",
-    "lint:editorconfig": "editorconfig-checker",
+    "lint:editorconfig": "editorconfig-checker -exclude dist/",
     "fix": "npm run fix:eslint",
     "fix:eslint": "npm run lint:eslint -- --fix",
     "test": "npm run lint && npm run test:unit",


### PR DESCRIPTION
We don't want to lint the `dist` folder.