### PR TITLE
QE-827: Fix dependabot auto assign reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       time: '08:00'
       timezone: America/Toronto
     versioning-strategy: increase
-    reviewers:
-      - Brightspace/quality-enablement
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']


### PR DESCRIPTION
Just removed it due to https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners