### PR TITLE
Switch to generating v3 reports for testing

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,7 @@
 {
   "spec": "test/**/*.test.js",
-  "reporter": "d2l-test-reporting/reporters/mocha.js"
+  "reporter": "d2l-test-reporting/reporters/mocha.js",
+  "reporterOptions": [
+    "reportVersionLatest=true"
+  ]
 }


### PR DESCRIPTION
This is still an experimental feature, do not use. Will eventually be the default wit v6 of `d2l-test-reporting`.

https://desire2learn.atlassian.net/browse/QE-651