### PR TITLE
Add language labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -26,7 +26,7 @@
   description: This doesn't seem right
   color: e4e669
 - name: javascript
-  description: Pull requests that update javascript code
+  description: Pull requests that update JavaScript code
   color: 168700
 - name: question
   description: Further information is requested

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -14,7 +14,7 @@
   description: New feature or request
   color: a2eeef
 - name: github-actions
-  description: GitHub Actions workflows or dependencies
+  description: Pull requests that update GitHub Actions code
   color: 000000
 - name: good first issue
   description: Good for newcomers

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -13,6 +13,9 @@
 - name: enhancement
   description: New feature or request
   color: a2eeef
+- name: github-actions
+  description: GitHub Actions workflows or dependencies
+  color: 000000
 - name: good first issue
   description: Good for newcomers
   color: 7057ff


### PR DESCRIPTION
Updates `.github/labels.yml` to add the missing language labels for this repository. This allows better filtering of PRs for later investigations.

QE-2110