### PR TITLE
QE-2110: Add labeler config and label CI job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.md'
+github-actions:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/*.yml
+javascript:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.js'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,13 @@ jobs:
           message: ${{steps.test-summary.outputs.report}}
           unique-key: test-summary-${{matrix.os.name}}
           post-mode: hide-previous
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Apply labels
+        uses: Brightspace/third-party-actions@actions/labeler


### PR DESCRIPTION
Adds a `.github/labeler.yml` and a `label` job to `ci.yml` so PRs are labeled automatically.