### PR TITLE
Add dependencies labeling rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: npm
     open-pull-requests-limit: 99
     directory: /
+    labels:
+      - dependencies
     schedule:
       interval: weekly
       time: '08:00'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,10 @@ documentation:
   - changed-files:
     - any-glob-to-any-file:
       - '**/*.md'
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - package-lock.json
 github-actions:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
Adds dependency labeling updates for repository automation by updating labeling configuration for dependency-related changes.

QE-2288