### PR TITLE
Normalize Dependabot AWS group name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       - dependency-name: eslint
         versions: '>= 10'
     groups:
-      aws-clients:
+      aws-sdk:
         dependency-type: production
         patterns:
           - '@aws-sdk/*'


### PR DESCRIPTION
Renames the Dependabot AWS SDK group to match the group naming used in the other repos.

QE-2288