### PR TITLE
Clarify action input contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ GitHub Action submit test reporting data to the framework.
   assume.
 * `report-path` (default: `./d2l-test-report.json`): Path to the D2L format test
   report JSON file for processing.
-* `lms-build-number`: The LMS build number of the site used to generate this
-  report. Will throw an error if provided and already present in the report.
-* `lms-instance-url`: The LMS instance URL of the site used to generate this
-  report. Will throw an error if provided and already present in the report.
+* `lms-build-number` (optional): The LMS build number of the site used to
+  generate this report. Will throw an error if provided and already present in
+  the report.
+* `lms-instance-url` (optional): The LMS instance URL of the site used to
+  generate this report. Will throw an error if provided and already present in
+  the report.
 * `inject-github-context` (default: `auto`): Change mode for injection of GitHub
   Actions context at report submission time.
   * `auto`: Injects GitHub Actions context into report if missing
@@ -74,6 +76,12 @@ GitHub Action submit test reporting data to the framework.
 * `debug` (default: `false`): Enable or disable debug mode. Will enable
   additional log messages. Does not stop final submission of report data to
   backend. Only really useful for debugging and testing.
+
+### Outputs
+
+This action does not define GitHub Actions outputs. When `post-summary` is
+enabled and `dry-run` is `false`, it writes links to the submitted report data
+to the GitHub Actions job summary instead.
 
 ## Authentication
 

--- a/action.yml
+++ b/action.yml
@@ -16,29 +16,22 @@ inputs:
     default: arn:aws:iam::427469055187:role/github+${{github.repository_owner == 'BrightspaceHypermediaComponents' && 'BHC' || github.repository_owner}}+${{github.event.repository.name}}
   report-path:
     description: Path to the D2L format test report JSON file for processing
-    required: true
     default: ./d2l-test-report.json
   lms-build-number:
     description: LMS build number used in the generation of this report
-    required: false
   lms-instance-url:
     description: LMS instance URL used in the generation of this report
-    required: false
   inject-github-context:
     description: Change mode for injection of GitHub Actions context at report submission time
-    required: true
     default: auto
   post-summary:
     description: Post information about data submitted to GitHub summary
-    required: false
     default: true
   dry-run:
     description: Run action in dry run mode. Will perform all operations except final submission of report data to backend
-    required: true
     default: false
   debug:
     description: Enable or disable debug mode. Will enable additional log messages. Does not stop final submission of report data to backend
-    required: true
     default: false
 runs:
   using: node24


### PR DESCRIPTION
Clarifies input defaults and optional LMS values in `README.md`, and removes redundant `required` metadata from `action.yml`. Documents that the action does not define outputs and uses the job summary when enabled.

Related: https://desire2learn.atlassian.net/browse/QE-2339