### PR TITLE
Label action metadata changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,7 @@ github-actions:
   - changed-files:
     - any-glob-to-any-file:
       - .github/workflows/*.yml
+      - action.yml
 javascript:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
Adds `action.yml` to the `github-actions` labeler group so action metadata changes receive the appropriate label.

Related: https://desire2learn.atlassian.net/browse/QE-2339